### PR TITLE
update tests with fixtures

### DIFF
--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -27,7 +27,7 @@ def get_z_encoder_for(
     ----------
     X : array, shape (n_trials, n_channels, n_times)
         The data on which to perform CSC.
-    D_hat : array, shape (n_trials, n_channels, n_times) or
+    D_hat : array, shape (n_atoms, n_channels, n_times) or
         (n_atoms, n_channels + atom_support)
         The dictionary used to encode the signal X. Can be either in the form
         of a full rank dictionary D (n_atoms, n_channels, atom_support) or with
@@ -75,7 +75,7 @@ def get_z_encoder_for(
 
     assert (D_hat is not None and len(D_hat.shape) in [2, 3]), (
         'D_hat should be a valid array of shape '
-        '(n_trials, n_channels, n_times) '
+        '(n_atoms, n_channels, n_times) '
         'or (n_atoms, n_channels + atom_support).'
     )
 

--- a/alphacsc/tests/test_encoder.py
+++ b/alphacsc/tests/test_encoder.py
@@ -12,29 +12,24 @@ N_CHANNELS, N_TIMES = 3, 30
 N_TIMES_ATOM, N_ATOMS = 6, 4
 
 
-rng = check_random_state(42)
-
-
-def make_X(n_trials):
-    ret = rng.randn(n_trials, N_CHANNELS, N_TIMES)
-    ret.setflags(write=False)
-    return ret
-
-
-X1 = make_X(n_trials=1)
-N_TRIALS_X2 = 2
-X2 = make_X(n_trials=N_TRIALS_X2)
-
-
-def make_D_hat(rank1=True):
-    return init_dictionary(
-        X1, N_ATOMS, N_TIMES_ATOM,
-        random_state=0, rank1=rank1)  # XXX change X1
+@pytest.fixture
+def rng():
+    return check_random_state(42)
 
 
 @pytest.fixture
-def D_hat(rank1=True):
-    return make_D_hat()
+def X(rng, n_trials):
+    return rng.randn(n_trials, N_CHANNELS, N_TIMES)
+
+
+@pytest.fixture
+def D_hat(X, rank1):
+    return init_dictionary(X,
+                           N_ATOMS,
+                           N_TIMES_ATOM,
+                           random_state=0,
+                           rank1=rank1
+                           )
 
 
 @pytest.mark.parametrize('solver_z', ['l-bfgs', 'lgcd'])
@@ -43,12 +38,14 @@ def D_hat(rank1=True):
 @pytest.mark.parametrize('loss', ['l2', 'dtw', 'whitening'])
 @pytest.mark.parametrize('uv_constraint', ['joint', 'separate'])
 @pytest.mark.parametrize('feasible_evaluation', [True, False])
-def test_get_encoder_for(solver_z, D_hat, algorithm, loss,
+@pytest.mark.parametrize('n_trials', [1, 2, 5])
+@pytest.mark.parametrize('rank1', [True, False])
+def test_get_encoder_for(X, solver_z, D_hat, algorithm, loss,
                          uv_constraint, feasible_evaluation):
     """Test for valid values."""
 
     with get_z_encoder_for(solver=solver_z,
-                           X=X2,
+                           X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
                            atom_support=N_TIMES_ATOM,
@@ -61,11 +58,14 @@ def test_get_encoder_for(solver_z, D_hat, algorithm, loss,
         assert z_encoder is not None
 
 
-def test_get_encoder_for_dicodile():
+@pytest.mark.parametrize('n_trials', [1])
+@pytest.mark.parametrize('rank1', [False])
+def test_get_encoder_for_dicodile(X, D_hat):
     pytest.importorskip('dicodile')
+
     with get_z_encoder_for(solver='dicodile',
-                           X=X1,
-                           D_hat=make_D_hat(rank1=False),
+                           X=X,
+                           D_hat=D_hat,
                            n_atoms=N_ATOMS,
                            atom_support=N_TIMES_ATOM,
                            n_jobs=2) as z_encoder:
@@ -73,65 +73,74 @@ def test_get_encoder_for_dicodile():
         assert z_encoder is not None
 
 
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
 @pytest.mark.parametrize('solver_z', [None, 'other'])
-def test_get_encoder_for_error_solver_z(D_hat,  solver_z):
+def test_get_encoder_for_error_solver_z(X, D_hat,  solver_z):
     """Tests for invalid values of `solver_z`."""
 
     with pytest.raises(ValueError,
                        match=f"unrecognized solver type: {solver_z}."):
         get_z_encoder_for(solver=solver_z,
-                          X=X2,
+                          X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
                           n_jobs=2)
 
 
-def test_get_encoder_for_error_z_kwargs(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_encoder_for_error_z_kwargs(X, D_hat):
     """Tests for invalid value of `z_kwargs`."""
 
     with pytest.raises(AssertionError, match=".*z_kwargs should.*"):
         get_z_encoder_for(z_kwargs=None,
-                          X=X2,
+                          X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
                           n_jobs=2)
 
 
-@pytest.mark.parametrize('X', [None, rng.rand(N_TRIALS_X2, N_CHANNELS)])
-def test_get_encoder_for_error_X(X, D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+@pytest.mark.parametrize('X_error', [None, np.zeros([2, N_CHANNELS])])
+def test_get_encoder_for_error_X(X_error, D_hat):
     """Tests for invalid values of `X`."""
 
     with pytest.raises(AssertionError,
                        match="X should be a valid array of shape.*"):
-        get_z_encoder_for(X=X,
+        get_z_encoder_for(X=X_error,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
                           n_jobs=2)
 
 
-@pytest.mark.parametrize('D_init', [None, np.zeros(N_TRIALS_X2)])
-def test_get_encoder_for_error_D_hat(D_init):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('D_init', [None, np.zeros(2)])
+def test_get_encoder_for_error_D_hat(X, D_init):
     """Tests for invalid values of `D_hat`."""
 
     with pytest.raises(AssertionError,
                        match="D_hat should be a valid array of shape.*"):
-        get_z_encoder_for(X=X2,
+        get_z_encoder_for(X=X,
                           D_hat=D_init,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
                           n_jobs=2)
 
 
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
 @pytest.mark.parametrize('algorithm', [None, 'other'])
-def test_get_encoder_for_error_algorithm(D_hat,  algorithm):
+def test_get_encoder_for_error_algorithm(X, D_hat,  algorithm):
     """Tests for invalid values of `algorithm`."""
 
     with pytest.raises(AssertionError,
                        match=f"unrecognized algorithm type: {algorithm}"):
-        get_z_encoder_for(X=X2,
+        get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
@@ -139,12 +148,14 @@ def test_get_encoder_for_error_algorithm(D_hat,  algorithm):
                           n_jobs=2)
 
 
-def test_get_encoder_for_error_reg(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_encoder_for_error_reg(X, D_hat):
     """Tests for invalid value of `reg`."""
 
     with pytest.raises(AssertionError,
                        match="reg value cannot be None."):
-        get_z_encoder_for(X=X2,
+        get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
@@ -152,13 +163,15 @@ def test_get_encoder_for_error_reg(D_hat):
                           n_jobs=2)
 
 
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
 @pytest.mark.parametrize('loss', [None, 'other'])
-def test_get_encoder_for_error_loss(D_hat,  loss):
+def test_get_encoder_for_error_loss(X, D_hat,  loss):
     """Tests for invalid values of `loss`."""
 
     with pytest.raises(AssertionError,
                        match=f"unrecognized loss type: {loss}."):
-        get_z_encoder_for(X=X2,
+        get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
@@ -166,12 +179,14 @@ def test_get_encoder_for_error_loss(D_hat,  loss):
                           n_jobs=2)
 
 
-def test_get_encoder_for_error_loss_params(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_encoder_for_error_loss_params(X, D_hat):
     """Tests for invalid value of `loss_params`."""
 
     with pytest.raises(AssertionError,
                        match="loss_params should be a valid dict or None."):
-        get_z_encoder_for(X=X2,
+        get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
@@ -179,14 +194,16 @@ def test_get_encoder_for_error_loss_params(D_hat):
                           n_jobs=2)
 
 
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
 @pytest.mark.parametrize('uv_constraint', [None, 'other'])
-def test_get_encoder_for_error_uv_constraint(D_hat,
+def test_get_encoder_for_error_uv_constraint(X, D_hat,
                                              uv_constraint):
     """Tests for invalid values of `uv_constraint`."""
 
     with pytest.raises(AssertionError,
                        match="unrecognized uv_constraint type.*"):
-        get_z_encoder_for(X=X2,
+        get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
                           atom_support=N_TIMES_ATOM,
@@ -194,11 +211,13 @@ def test_get_encoder_for_error_uv_constraint(D_hat,
                           n_jobs=2)
 
 
-def test_get_z_hat(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_z_hat(X, D_hat):
     """Test for valid values."""
 
     # tests when use_sparse_z = False
-    with get_z_encoder_for(X=X2,
+    with get_z_encoder_for(X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
                            atom_support=N_TIMES_ATOM,
@@ -213,7 +232,7 @@ def test_get_z_hat(D_hat):
 
     # tests when use_sparse_z = True
     with get_z_encoder_for(solver='lgcd',
-                           X=X2,
+                           X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
                            atom_support=N_TIMES_ATOM,
@@ -230,10 +249,12 @@ def test_get_z_hat(D_hat):
             assert matrix.count_nonzero()
 
 
-def test_get_cost(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_cost(X, D_hat):
     """Test for valid values."""
 
-    with get_z_encoder_for(X=X2,
+    with get_z_encoder_for(X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
                            atom_support=N_TIMES_ATOM,
@@ -248,16 +269,18 @@ def test_get_cost(D_hat):
         assert final_cost < initial_cost
 
         X_hat = construct_X_multi(z_hat, D_hat, n_channels=N_CHANNELS)
-        cost = compute_objective(X=X2, X_hat=X_hat, z_hat=z_hat, reg=0.1,
+        cost = compute_objective(X=X, X_hat=X_hat, z_hat=z_hat, reg=0.1,
                                  D=D_hat)
 
         assert np.isclose(cost, final_cost)
 
 
-def test_compute_z(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_compute_z(X, D_hat):
     """Test for valid values."""
 
-    with get_z_encoder_for(X=X2,
+    with get_z_encoder_for(X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
                            atom_support=N_TIMES_ATOM,
@@ -266,24 +289,28 @@ def test_compute_z(D_hat):
         assert z_encoder.get_z_hat().any()
 
 
-def test_compute_z_partial(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_compute_z_partial(X, D_hat, n_trials, rng):
     """Test for valid values."""
 
-    with get_z_encoder_for(X=X2,
+    with get_z_encoder_for(X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
                            atom_support=N_TIMES_ATOM,
                            n_jobs=2) as z_encoder:
 
-        i0 = rng.choice(N_TRIALS_X2, 1, replace=False)
+        i0 = rng.choice(n_trials, 1, replace=False)
         z_encoder.compute_z_partial(i0)
         assert z_encoder.get_z_hat().any()
 
 
-def test_get_sufficient_statistics(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_sufficient_statistics(X, D_hat):
     """Test for valid values."""
 
-    z_encoder = get_z_encoder_for(X=X2,
+    z_encoder = get_z_encoder_for(X=X,
                                   D_hat=D_hat,
                                   n_atoms=N_ATOMS,
                                   atom_support=N_TIMES_ATOM,
@@ -296,13 +323,15 @@ def test_get_sufficient_statistics(D_hat):
     assert ztz is not None and np.allclose(ztz, compute_ztz(z_hat,
                                                             N_TIMES_ATOM))
 
-    assert ztX is not None and np.allclose(ztX, compute_ztX(z_hat, X2))
+    assert ztX is not None and np.allclose(ztX, compute_ztX(z_hat, X))
 
 
-def test_get_sufficient_statistics_error(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_sufficient_statistics_error(X, D_hat):
     """Test for invalid call to function."""
 
-    z_encoder = get_z_encoder_for(X=X2,
+    z_encoder = get_z_encoder_for(X=X,
                                   D_hat=D_hat,
                                   n_atoms=N_ATOMS,
                                   atom_support=N_TIMES_ATOM,
@@ -314,26 +343,30 @@ def test_get_sufficient_statistics_error(D_hat):
         z_encoder.get_sufficient_statistics()
 
 
-def test_get_sufficient_statistics_partial(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_sufficient_statistics_partial(X, D_hat, n_trials, rng):
     """Test for valid values."""
 
-    z_encoder = get_z_encoder_for(X=X2,
+    z_encoder = get_z_encoder_for(X=X,
                                   D_hat=D_hat,
                                   n_atoms=N_ATOMS,
                                   atom_support=N_TIMES_ATOM,
                                   n_jobs=2)
 
-    i0 = rng.choice(N_TRIALS_X2, 1, replace=False)
+    i0 = rng.choice(n_trials, 1, replace=False)
     z_encoder.compute_z_partial(i0)
 
     ztz_i0, ztX_i0 = z_encoder.get_sufficient_statistics_partial()
     assert ztz_i0 is not None and ztX_i0 is not None
 
 
-def test_get_sufficient_statistics_partial_error(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_get_sufficient_statistics_partial_error(X, D_hat):
     """Test for invalid call to function."""
 
-    z_encoder = get_z_encoder_for(X=X2,
+    z_encoder = get_z_encoder_for(X=X,
                                   D_hat=D_hat,
                                   n_atoms=N_ATOMS,
                                   atom_support=N_TIMES_ATOM,
@@ -345,10 +378,12 @@ def test_get_sufficient_statistics_partial_error(D_hat):
         z_encoder.get_sufficient_statistics_partial()
 
 
-def test_add_one_atom(D_hat):
+@pytest.mark.parametrize('n_trials', [2])
+@pytest.mark.parametrize('rank1', [True])
+def test_add_one_atom(X, D_hat):
     """Test for valid values."""
 
-    with get_z_encoder_for(X=X2,
+    with get_z_encoder_for(X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
                            atom_support=N_TIMES_ATOM,


### PR DESCRIPTION
Hi @rprimet, 

I did not feel comfortable with the way we supply X and D_hat to the tests. So I tried another way of supplying them via fixtures. Please check and let me know if you like it. 

Please see [this link](https://docs.pytest.org/en/latest/how-to/fixtures.html#fixtures-can-be-requested-more-than-once-per-test-return-values-are-cached) which explains that if some fixtures are called more than once in the same test, they are cached and the test function is guaranteed to have the same fixtures. So when we get X and D_hat, it is guaranteed that D_hat will be created from the same X provided in the test function.